### PR TITLE
test: make config-store test use tracked fallback

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -13,3 +13,9 @@
 - [x] Explore existing code
 - [x] Implement changes
 - [x] Test & push
+
+# Issue 4 review follow-up - 2026-05-17
+- [x] Created review-fix worktree from origin/review
+- [x] Checked PR #6 and issue #4 for actionable review comments (none present)
+- [x] Ran required gates and found `test:config-store` depended on ignored local config
+- [x] Updated config-store test to fall back to tracked example config when local config is absent

--- a/scripts/test-config-store.mjs
+++ b/scripts/test-config-store.mjs
@@ -92,7 +92,9 @@ async function run() {
   const tempDir = mkdtempSync(join(tmpdir(), 'config-store-test-'));
   const configPath = join(tempDir, 'characters.json');
   const schemaPath = resolve(rootDir, 'config/characters.schema.json');
-  const sourceConfigPath = resolve(rootDir, 'config/characters-local.json');
+  const localConfigPath = resolve(rootDir, 'config/characters-local.json');
+  const exampleConfigPath = resolve(rootDir, 'config/characters.json.example');
+  const sourceConfigPath = fs.existsSync(localConfigPath) ? localConfigPath : exampleConfigPath;
   copyFileSync(sourceConfigPath, configPath);
 
   const snapshotOpts = {


### PR DESCRIPTION
## Summary
- Makes `test:config-store` independent of ignored `config/characters-local.json` by falling back to tracked `config/characters.json.example`.
- Records the review follow-up in `PROGRESS.md`.

## Testing
- `node --check src/api.mjs`
- `node --check src/services/skill-rotation.mjs`
- `node --check src/routines/skill-rotation/index.mjs`
- `node --check src/routines/skill-rotation/npc-tasks.mjs`
- `node --check src/routines/skill-rotation/item-tasks.mjs`
- `npm run test:skill-rotation`
- `npm run test:config-store`

Note: `npm run test:all` still requires `ARTIFACTS_TOKEN`; it reached `test-gear-state` and failed on the missing token in this clean worktree.

Follow-up for #4.
